### PR TITLE
mark session as stopped when terminated

### DIFF
--- a/blpapijs.cpp
+++ b/blpapijs.cpp
@@ -1381,6 +1381,9 @@ Session::processMessage(Isolate *isolate,
     Handle<Value> argv[2];
 
     const blpapi::Name& messageType = msg.messageType();
+    if ("SessionTerminated" == messageType) {
+        d_stopped = true;
+    }
 #if NODE_VERSION_AT_LEAST(0, 11, 0)
     argv[0] = String::NewFromUtf8(isolate,
                                   messageType.string(),


### PR DESCRIPTION
This change marks the session as being stopped when a
'SessionTerminated' event is emitted from the Bloomberg Open API.  This
makes the blpapi-node API eaiser to use in the situation where the
connection goes down, the 'SessionTerminated' event is emitted and the
user of the API can immediately invoke '.destroy()'.  Otherwise, the
user of the API would need to  invoke '.stop()', but would never get
another 'SessionTerminated' event to then call '.destroy()'.
