### PR TITLE
Added support for io.js v1.0 release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Dependencies
 
 This module requires:
 
-+ Node.js version >= **0.6.x**
++ Node.js version >= **0.6.x** (io.js >= **1.0.x** is supported)
 + Linux, Windows, or Mac OS X (32 or 64-bit)
 + GCC (Linux), MSVC++ (Windows), or Xcode (Mac OS X)
 + Bloomberg Desktop API (DAPI), Server API (SAPI), or [B-PIPE] subscription

--- a/blpapijs.cpp
+++ b/blpapijs.cpp
@@ -1084,11 +1084,11 @@ Session::elementToValue(Isolate *isolate, const blpapi::Element& e)
             } else {
                 sev = elementValueToValue(isolate, se);
             }
-#if NODE_VERSION_AT_LEAST(0, 11, 0)
-            o->Set(String::NewFromUtf8(isolate,
-                                       se.name().string(),
-                                       String::kNormalString,
-                                       se.name().length()),
+#if NODE_VERSION_AT_LEAST(0, 11, 15)
+            o->ForceSet(String::NewFromUtf8(isolate,
+                                            se.name().string(),
+                                            String::kNormalString,
+                                            se.name().length()),
                    sev, (PropertyAttribute)(ReadOnly | DontDelete));
 #else
             o->Set(String::New(se.name().string(), se.name().length()),
@@ -1393,17 +1393,17 @@ Session::processMessage(Isolate *isolate,
     argv[0] = String::New(messageType.string(), messageType.length());
 #endif
 
-#if NODE_VERSION_AT_LEAST(0, 11, 0)
+#if NODE_VERSION_AT_LEAST(0, 11, 15)
     Local<Object> o = Object::New(isolate);
-    o->Set(Local<String>::New(isolate, s_event_type),
-           eventTypeToString(isolate, et),
-           (PropertyAttribute)(ReadOnly | DontDelete));
-    o->Set(Local<String>::New(isolate, s_message_type),
-           argv[0],
-           (PropertyAttribute)(ReadOnly | DontDelete));
-    o->Set(Local<String>::New(isolate, s_topic_name),
-           String::NewFromUtf8(isolate, msg.topicName()),
-           (PropertyAttribute)(ReadOnly | DontDelete));
+    o->ForceSet(Local<String>::New(isolate, s_event_type),
+                eventTypeToString(isolate, et),
+                (PropertyAttribute)(ReadOnly | DontDelete));
+    o->ForceSet(Local<String>::New(isolate, s_message_type),
+                argv[0],
+                (PropertyAttribute)(ReadOnly | DontDelete));
+    o->ForceSet(Local<String>::New(isolate, s_topic_name),
+                String::NewFromUtf8(isolate, msg.topicName()),
+                (PropertyAttribute)(ReadOnly | DontDelete));
 #else
     Local<Object> o = Object::New();
     o->Set(s_event_type, eventTypeToString(isolate, et),
@@ -1445,12 +1445,12 @@ Session::processMessage(Isolate *isolate,
 #endif
         }
     }
-#if NODE_VERSION_AT_LEAST(0, 11, 0)
-    o->Set(Local<String>::New(isolate, s_correlations),
-           correlations, (PropertyAttribute)(ReadOnly | DontDelete));
+#if NODE_VERSION_AT_LEAST(0, 11, 15)
+    o->ForceSet(Local<String>::New(isolate, s_correlations),
+                correlations, (PropertyAttribute)(ReadOnly | DontDelete));
 
-    o->Set(Local<String>::New(isolate, s_data),
-           elementToValue(isolate, msg.asElement()));
+    o->ForceSet(Local<String>::New(isolate, s_data),
+                elementToValue(isolate, msg.asElement()));
 #else
     o->Set(s_correlations, correlations,
            (PropertyAttribute)(ReadOnly | DontDelete));


### PR DESCRIPTION
The updated v8 version contained in the io.js v1.0 release requires
calling `ForceSet` instead of `Set` if `PropertyAttribute` values
are specified.

Provides compatibility for tracking ticket iojs/io.js#456