### PR TITLE
Expose createIdentity, generateToken & sendAuthorizationRequest

### DIFF
--- a/blpapi.js
+++ b/blpapi.js
@@ -39,8 +39,7 @@ var getError = function () {
 
 var invoke = function(func) {
     try {
-        return func.apply(this,
-                          Array.prototype.slice.call(arguments, 1));
+        return func.apply(this, arguments[1]);
     } catch(err) {
         throw getError(err);
     }
@@ -55,66 +54,84 @@ exports.Session = function(args) {
 };
 util.inherits(exports.Session, EventEmitter);
 
+// Usage: no args
+// Returns: this(Session Object)
 exports.Session.prototype.start =
     function() {
-        return invoke.call(this.session, this.session.start);
+        return invoke.call(this.session, this.session.start, arguments);
     }
-exports.Session.prototype.authorize =
-    function(uri, cid) {
-        return invoke.call(this.session, this.session.authorize, uri, cid);
-    }
-exports.Session.prototype.authorizeUser =
-    function(request, cid) {
-        return invoke.call(this.session,
-                           this.session.authorizeUser,
-                           request,
-                           cid);
-    }
+
+// Usage: no args
+// Returns: this(Session Object)
 exports.Session.prototype.stop =
     function() {
-        return invoke.call(this.session, this.session.stop);
+        return invoke.call(this.session, this.session.stop, arguments);
     }
+
+// Usage: no args
+// Returns: this(Session Object)
 exports.Session.prototype.destroy =
     function() {
-        return invoke.call(this.session, this.session.destroy);
+        return invoke.call(this.session, this.session.destroy, arguments);
     }
+
+// Usage: <uri>, <cid>
+// Returns: cid
 exports.Session.prototype.openService =
-    function(uri, cid) {
-        return invoke.call(this.session, this.session.openService, uri, cid);
+    function() {
+        return invoke.call(this.session, this.session.openService, arguments);
     }
+
+// Usage: <subscriptions>, [identity], [label]
+// Returns: this(Session Object)
 exports.Session.prototype.subscribe =
-    function(sub, arg2, arg3) {
-        var identity = arg2;
-        var label = arg3;
-        if (2 === arguments.length && typeof arg2 === 'string') {
-            identity = undefined;
-            label = arg2;
-        }
-        return invoke.call(this.session,
-                           this.session.subscribe,
-                           sub,
-                           identity,
-                           label);
+    function() {
+        return invoke.call(this.session, this.session.subscribe, arguments);
     }
+
+// Usage: <subscriptions>, [identity], [label]
+// Returns: this(Session Object)
 exports.Session.prototype.resubscribe =
-    function(sub, label) {
-        return invoke.call(this.session, this.session.resubscribe, sub, label);
+    function() {
+        return invoke.call(this.session, this.session.resubscribe, arguments);
     }
+
+// Usage: <subscriptions>, [identity], [label]
+// Returns: this(Session Object)
 exports.Session.prototype.unsubscribe =
-    function(sub, label) {
-        return invoke.call(this.session, this.session.unsubscribe, sub, label);
+    function() {
+        return invoke.call(this.session, this.session.unsubscribe, arguments);
     }
+
+// Usage: <uri>, <request_name>, <request_body>, <cid>, [identity], [label]
+// Returns: cid
 exports.Session.prototype.request =
-    function(uri, name, request, cid, arg5, arg6) {
-        var identity = arg5;
-        var label = arg6;
-        if (5 === arguments.length && typeof arg5 === 'string') {
-            identity = undefined;
-            label = arg5;
-        }
-        return invoke.call(this.session, this.session.request,
-                           uri, name, request, cid, identity, label);
+    function() {
+        return invoke.call(this.session, this.session.request, arguments);
     }
+
+// Usage: no args
+// Returns: Identity
+exports.Session.prototype.createIdentity =
+    function() {
+        return invoke.call(this.session, this.session.createIdentity, arguments);
+    }        
+
+// Usage: <cid>
+// Returns: cid
+exports.Session.prototype.generateToken =
+    function() {
+        return invoke.call(this.session, this.session.generateToken, arguments);
+    }
+
+// Usage: <token>, <identity>, <cid>
+// Returns: cid
+exports.Session.prototype.sendAuthorizationRequest =
+    function() {
+        return invoke.call(this.session, this.session.sendAuthorizationRequest, arguments);
+    }
+
+
 
 // Local variables:
 // c-basic-offset: 4

--- a/blpapijs.cpp
+++ b/blpapijs.cpp
@@ -283,7 +283,8 @@ public:
     static void Request(const FunctionCallbackInfo<Value>& args);
     static void CreateIdentity(const FunctionCallbackInfo<Value>& args);
     static void GenerateToken(const FunctionCallbackInfo<Value>& args);
-    static void SendAuthorizationRequest(const FunctionCallbackInfo<Value>& args);
+    static void SendAuthorizationRequest(
+        const FunctionCallbackInfo<Value>& args);
 
 private:
     Session();
@@ -400,7 +401,9 @@ Session::Initialize(Handle<Object> target)
     NODE_SET_PROTOTYPE_METHOD(t, "request", Request);
     NODE_SET_PROTOTYPE_METHOD(t, "createIdentity", CreateIdentity);
     NODE_SET_PROTOTYPE_METHOD(t, "generateToken", GenerateToken);
-    NODE_SET_PROTOTYPE_METHOD(t, "sendAuthorizationRequest", SendAuthorizationRequest);
+    NODE_SET_PROTOTYPE_METHOD(t,
+                              "sendAuthorizationRequest",
+                              SendAuthorizationRequest);
 
     target->Set(String::NewFromUtf8(isolate, "Session",
                                     v8::String::kInternalizedString),
@@ -704,8 +707,8 @@ Session::subscribe(const FunctionCallbackInfo<Value>& args, int action)
     if (args.Length() == 3
         && !(args[1]->IsObject() && args[2]->IsString())) {
         RetThrowException(Exception::Error(NEW_STRING(
-            "3 parameters combinations: "
-            "Identity object, and label as second & third parameter.")));   
+            "3 parameters combinations must be: "
+            "Subscriptions array, identity object, and label string.")));
     }
     if (args.Length() > 3) {
         RetThrowException(Exception::Error(NEW_STRING(
@@ -820,7 +823,10 @@ Session::subscribe(const FunctionCallbackInfo<Value>& args, int action)
         else if (action == 2)
             session->d_session->unsubscribe(sl);
         else
-            session->d_session->subscribe(sl, *identity, *labelv, labelv.length());
+            session->d_session->subscribe(sl,
+                                          *identity,
+                                          *labelv,
+                                          labelv.length());
     }
 
     BLPAPI_EXCEPTION_CATCH_RETURN
@@ -873,8 +879,9 @@ Session::Request(const FunctionCallbackInfo<Value>& args)
     if (args.Length() == 6
         && !(args[4]->IsObject() && args[5]->IsString())) {
         RetThrowException(Exception::Error(NEW_STRING(
-            "6 parameters combinations: "
-            "Identity object, and label as fifth & sixth parameter.")));   
+            "6 parameters combinations must be: "
+            "Service UIR, request name, request parameters object, "
+            "integer correlation id, identity object and label string.")));
     }
     if (args.Length() > 6) {
         RetThrowException(Exception::Error(NEW_STRING(
@@ -1045,7 +1052,8 @@ Session::SendAuthorizationRequest(const FunctionCallbackInfo<Value>& args)
     
     BLPAPI_EXCEPTION_TRY
 
-    blpapi::Service authService = session->d_session->getService("//blp/apiauth");
+    blpapi::Service authService = session->d_session
+                                    ->getService("//blp/apiauth");
     blpapi::Request authRequest = authService.createAuthorizationRequest(
                                                        "AuthorizationRequest");
     authRequest.set("token", token.c_str());

--- a/examples/AuthorizationApplication.js
+++ b/examples/AuthorizationApplication.js
@@ -32,7 +32,6 @@ session.on('ServiceOpened', function(m) {
 session.on('TokenGenerationSuccess', function(m) {
     // Match correlation identifier used when generating token
     if (m.correlations[0].value == request_token) {
-        console.log('Token generation successful.');
         var token = m.data.token;
         var identity = session.createIdentity();
         session.sendAuthorizationRequest(token, identity, request_apiauth);


### PR DESCRIPTION
This PR modifies the binding layer code to be almost 1-to-1 mapping to the C++ SDK, specifically around the authorization requests. The authentication/authorization is now following the same 3 steps as documented in the developer guide:

- `session.generateToken()`: Generate token based on the session options. Async. Generate `TokenGenerationSuccess` or `TokenGenerationFailure` events.
- `session.createIdentity()`: Create opaque identity object. Sync. Return a javascript identity object.
- `session.sendAuthorizationRequest()`: Send authorization request based on token & identity. Async. Generate `AuthorizationSuccess` or `AuthorizationFailure` events.

This change also removes the default identity that used to stored inside the binding layer, and update the `AuthorizationApplication.js` example.

This closes #43, #44, #45 