### PR TITLE
call emit with this bind to the session object itself

### DIFF
--- a/blpapijs.cpp
+++ b/blpapijs.cpp
@@ -1431,11 +1431,12 @@ void
 Session::emit(Isolate *isolate, int argc, Handle<Value> argv[])
 {
     HandleScope scope(isolate);
+    Local<Object> sessionJS = handle(isolate);
     Local<Function> emit =
         Local<Function>::Cast(
-                handle(isolate)->Get(Local<String>::New(isolate, s_emit)));
+                sessionJS->Get(Local<String>::New(isolate, s_emit)));
     node::MakeCallback(isolate,
-                       isolate->GetCurrentContext()->Global(),
+                       sessionJS,
                        emit, argc, argv);
 }
 


### PR DESCRIPTION
This PR changes `this` to bind to `session` object when we call `emit` from C++ to JS land.

As part of the re-factoring JS code we found that the `emit` function was called in JS land with `this` bind to the `global` context. This does not work well with node `EventEmitter` implementation unless you bind `this` back to the `session` object explicitly(use `.bind()` or closure).