### PR TITLE
Add `node-gyp` as a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 Debug/
 Release/
 npm-debug.log
+/node_modules/

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "dependencies": {
     "custom-error-generator": "7.0.0"
   },
+  "devDependencies": {
+    "node-gyp": "^2.0.1"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/bloomberg/blpapi-node.git"


### PR DESCRIPTION
`node-gyp` is bundled with `npm`, which gets executed with `npm
install`.  However, when developing `blpapi-node`, it is useful to use
`node-gyp` directly as a development dependency.