### PR TITLE
Support node >=0.12 and iojs >= 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: node_js
 node_js:
   - "0.12"
-  - "0.11"
-  - "0.10"
-  - "0.8"
-  - "0.6"
-  - iojs
+  - "iojs"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Dependencies
 
 This module requires:
 
-+ Node.js version >= **0.6.x** (io.js >= **1.0.x** is supported)
++ Node.js version >= **0.12.x** (io.js >= **1.0.x** is supported)
 + Linux, Windows, or Mac OS X (32 or 64-bit)
 + GCC (Linux), MSVC++ (Windows), or Xcode (Mac OS X)
 + Bloomberg Desktop API (DAPI), Server API (SAPI), or [B-PIPE] subscription

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "market"
   ],
   "license": "MIT",
-  "engines": { "node": ">=0.6" }
+  "engines": {
+    "node": ">=0.12",
+    "iojs": ">=1.0"
+  }
 }


### PR DESCRIPTION
By only supporting the latest stable versions of `node` and `iojs`, we can also remove the the backwards compatible`#ifdef`ed code.